### PR TITLE
fix a typo

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -22,7 +22,7 @@ Future<ApiObject> rootObject() async {
 
     var firebaseBaseUri = 'https://${firebaseDomain}';
 
-    var availableLabelsfirebasePath = getLablesPath(githubRepo);
+    var availableLabelsfirebasePath = getLabelsPath(githubRepo);
 
     var myLabelsFirebaseUrl = getMyLabelsPath(currentUser.email, githubRepo);
 

--- a/lib/src/server_utils.dart
+++ b/lib/src/server_utils.dart
@@ -47,13 +47,13 @@ String get firebaseSecret => getEnvValue('firebaseSecret');
 
 String get firebaseDomain => getEnvValue('firebaseDomain');
 
-String getLablesPath(String repoFullName) =>
+String getLabelsPath(String repoFullName) =>
     p.url.join('repos', encodeKey(repoFullName), 'labels');
 
 Uri getLabelsUri(String repoFullName) => new Uri(
     scheme: 'https',
     host: firebaseDomain,
-    path: '${getLablesPath(repoFullName)}.json');
+    path: '${getLabelsPath(repoFullName)}.json');
 
 Uri getUsersForRepoUri(String repoFullName) => new Uri(
     scheme: 'https',


### PR DESCRIPTION
Fix a type - `getLablesPath` ==> `getLabelsPath`.
